### PR TITLE
margin fix on desktop & mobile

### DIFF
--- a/src/components/flip-click.css
+++ b/src/components/flip-click.css
@@ -2,7 +2,17 @@
   width: 200px;
   height: 250px;
   perspective: 600px;
-  margin-right: 40px;
+}
+
+@media (min-width: 701px) {
+  .scene {
+    margin-left: 20px;
+  }
+
+  .scene:first-child {
+    margin-right: 20px;
+    margin-left: 0px;
+  }
 }
 
 .card {

--- a/src/containers/That.jsx
+++ b/src/containers/That.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React from "react";
 // import RankDB from '../components/RankDB';
-import Holder from '../components/Holder';
-import Loading from '../components/Loading';
-import styled from 'styled-components';
-import { client, gql } from '../client';
+import Holder from "../components/Holder";
+import Loading from "../components/Loading";
+import styled from "styled-components";
+import { client, gql } from "../client";
 
-import '../components/flip-click.css';
-import loadnoun from '../components/logo-noun.gif';
+import "../components/flip-click.css";
+import loadnoun from "../components/logo-noun.gif";
 
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
 
 import { withRouter } from "react-router-dom";
 
@@ -44,7 +44,7 @@ const HolderWrapper = styled.div`
 
 const TitleWrapper = styled.div`
   /*font-family: 'Cedarville Cursive', cursive;*/
-  font-family: 'Sacramento', cursive;
+  font-family: "Sacramento", cursive;
   font-size: 61px;
   font-weight: bold;
   color: #2c3e50;
@@ -57,10 +57,13 @@ const LeaderboardLink = styled.div`
   padding: 10px 20px;
   border-radius: 25px;
   cursor: pointer;
+
+  @media (max-width: 700px) {
+    margin: 15px 0px;
+  }
 `;
 
 class That extends React.Component {
-
   constructor() {
     super();
     this.state = {
@@ -85,7 +88,6 @@ class That extends React.Component {
   }
 
   async getNextPair(prevId, otherId) {
-
     const nextPair = await client.query({
       query: gql`
         query NextPair($prevId: Int, $otherId: Int) {
@@ -104,7 +106,7 @@ class That extends React.Component {
       variables: {
         prevId: prevId,
         otherId: otherId,
-      }
+      },
     });
 
     return nextPair.data.getNextPair;
@@ -123,14 +125,13 @@ class That extends React.Component {
       variables: {
         prevId: prevId,
         otherId: otherId,
-      }
+      },
     });
 
     return next.data.getNext;
   }
 
   async updateRank(id, over) {
-
     const { address } = this.props;
 
     if (!address) {
@@ -139,25 +140,31 @@ class That extends React.Component {
 
     const vote = await client.mutate({
       mutation: gql`
-        mutation VoteMutation($leftHash: Int, $rightHash: Int, $address: String) {
-         addVote(id: $leftHash, over: $rightHash, address: $address)
-       }
-      `, variables: {
+        mutation VoteMutation(
+          $leftHash: Int
+          $rightHash: Int
+          $address: String
+        ) {
+          addVote(id: $leftHash, over: $rightHash, address: $address)
+        }
+      `,
+      variables: {
         leftHash: id,
         rightHash: over,
         address: address,
-      }
+      },
     });
   }
 
   async holderClick(option) {
-
     const { left, right, limit, isFrontLeft, isFrontRight } = this.state;
 
-    option ? this.updateRank(left.hash, right.hash) : this.updateRank(right.hash, left.hash);
+    option
+      ? this.updateRank(left.hash, right.hash)
+      : this.updateRank(right.hash, left.hash);
 
     if (limit == 12) {
-      this.props.history.push('/nouns/leaderboard')
+      this.props.history.push("/nouns/leaderboard");
     }
 
     const nextPair = await this.getNextPair(left.hash, right.hash);
@@ -171,64 +178,94 @@ class That extends React.Component {
   }
 
   componentDidMount() {
-    client.query({
-      query: gql`{
-        getPair {
-          left {
-            hash,
-            uri
-          },
-          right {
-            hash,
-            uri
+    client
+      .query({
+        query: gql`
+          {
+            getPair {
+              left {
+                hash
+                uri
+              }
+              right {
+                hash
+                uri
+              }
+            }
           }
-        }
-      }
-      `
-    }).then(response => {
-      this.setState({
-        left: response.data.getPair.left,
-        right: response.data.getPair.right,
+        `,
+      })
+      .then((response) => {
+        this.setState({
+          left: response.data.getPair.left,
+          right: response.data.getPair.right,
+        });
       });
-    });
   }
 
-
   render() {
-
     const { left, right, isFrontLeft, isFrontRight, defaultUri } = this.state;
     return (
       <ThatWrapper>
-        <TitleWrapper>
-          this or that
-        </TitleWrapper>
+        <TitleWrapper>this or that</TitleWrapper>
+
         <HolderWrapper>
           <div className="scene">
             <div className={isFrontLeft ? "card" : "card is-flipped"}>
-              <div className={isFrontLeft ? "card__face" : "card__face front--hidden"}>
-                <Holder text="this" imgSrc={!isFrontLeft ? defaultUri : left.uri} click={() => this.holderClick(true)}></Holder>
+              <div
+                className={
+                  isFrontLeft ? "card__face" : "card__face front--hidden"
+                }
+              >
+                <Holder
+                  text="this"
+                  imgSrc={!isFrontLeft ? defaultUri : left.uri}
+                  click={() => this.holderClick(true)}
+                ></Holder>
               </div>
+
               <div className="card__face card__face--back">
-                <Holder text="this" imgSrc={!isFrontLeft ? left.uri : defaultUri} click={() => this.holderClick(true)}></Holder>
+                <Holder
+                  text="this"
+                  imgSrc={!isFrontLeft ? left.uri : defaultUri}
+                  click={() => this.holderClick(true)}
+                ></Holder>
               </div>
             </div>
           </div>
+
           <div className="scene">
             <div className={isFrontRight ? "card" : "card is-flipped-right"}>
-              <div className={isFrontRight ? "card__face" : "card__face front--hidden"}>
-                <Holder text="that" imgSrc={!isFrontRight ? defaultUri : right.uri} click={() => this.holderClick(false)}></Holder>
+              <div
+                className={
+                  isFrontRight ? "card__face" : "card__face front--hidden"
+                }
+              >
+                <Holder
+                  text="that"
+                  imgSrc={!isFrontRight ? defaultUri : right.uri}
+                  click={() => this.holderClick(false)}
+                ></Holder>
               </div>
+
               <div className="card__face card__face--back">
-                <Holder text="that" imgSrc={!isFrontRight ? right.uri : defaultUri} click={() => this.holderClick(false)}></Holder>
+                <Holder
+                  text="that"
+                  imgSrc={!isFrontRight ? right.uri : defaultUri}
+                  click={() => this.holderClick(false)}
+                ></Holder>
               </div>
             </div>
           </div>
         </HolderWrapper>
+
         <Link className="a-text" to="/nouns/leaderboard">
-          <LeaderboardLink><i className="gg-crown"></i>&nbsp;&nbsp;Affinity Ranking</LeaderboardLink>
+          <LeaderboardLink>
+            <i className="gg-crown"></i>&nbsp;&nbsp;Affinity Ranking
+          </LeaderboardLink>
         </Link>
       </ThatWrapper>
-    )
+    );
   }
 }
 


### PR DESCRIPTION
**Desktop**
Dispersed the 40px right margin between both Nouns, 20px right for the left Noun, and 20px left for the right Noun. Now they're even with the logo & the middle of the page. Added media query to only fix this on large screens.
<img width="1440" alt="Screen Shot 2021-09-06 at 2 25 04 PM" src="https://user-images.githubusercontent.com/26611339/132266051-6cafc713-9b31-415f-b03d-a42487606d66.png">


**Mobile**
Gave extra top & bottom margin to the button on mobile. It's now aligned and not touching the other elements.
<img width="1068" alt="Screen Shot 2021-09-06 at 2 23 08 PM" src="https://user-images.githubusercontent.com/26611339/132266077-429daf7e-8cfb-4952-9e35-7279699e556e.png">
